### PR TITLE
REFACTOR: revert login serializer to use default jwt auth serializer

### DIFF
--- a/ecommerce_backend/settings/base.py
+++ b/ecommerce_backend/settings/base.py
@@ -162,7 +162,7 @@ REST_AUTH = {
 
     # CRUCIAL: Tell dj-rest-auth to use the JWTSerializer to output tokens in the body
     'SERIALIZERS': {
-        'LOGIN_SERIALIZER': 'accounts.serializers.CustomJWTLoginSerializer',
+        'LOGIN_SERIALIZER': 'dj_rest_auth.jwt_auth.serializers.JWTSerializer',
         'TOKEN_SERIALIZER': 'dj_rest_auth.jwt_auth.serializers.JWTSerializer',
     },
 }


### PR DESCRIPTION
'LOGIN_SERIALIZER': 'dj_rest_auth.jwt_auth.serializers.JWTSerializer',
